### PR TITLE
Potential fix for code scanning alert no. 12: Client-side cross-site scripting

### DIFF
--- a/blog/posts/index.html
+++ b/blog/posts/index.html
@@ -701,7 +701,11 @@
 
             } catch(e) {
                 loading.style.display = 'none';
-                mdBody.innerHTML = `<div class="post-error">[ERROR] could not load writeup: ${postPath}<br/>make sure the file exists in _posts/</div>`;
+                mdBody.innerHTML = `<div class="post-error">[ERROR] could not load writeup: <span class="post-error-path"></span><br/>make sure the file exists in _posts/</div>`;
+                const errorPathEl = mdBody.querySelector('.post-error-path');
+                if (errorPathEl) {
+                    errorPathEl.textContent = postPath || '';
+                }
                 mdBody.style.display = 'block';
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/3rr0r-505/3rr0r-505.github.io/security/code-scanning/12](https://github.com/3rr0r-505/3rr0r-505.github.io/security/code-scanning/12)

In general, the problem is that untrusted data from the URL is being written directly into `innerHTML`. The fix is to either (a) avoid using `innerHTML` with untrusted strings, instead creating DOM nodes and setting `textContent`, or (b) sanitize/escape the untrusted data before interpolation. Since we only need to show `postPath` as text in an error message, the safest and least intrusive fix is to remove the interpolation from the HTML string, set a static error container via `innerHTML`, and then insert `postPath` via `textContent` so it is properly encoded as text.

Concretely, in `blog/posts/index.html` within the `catch` block of `loadPost`, replace the line that sets `mdBody.innerHTML` with a template literal containing `${postPath}` by: (1) setting `mdBody.innerHTML` to a static `<div class="post-error">` without `postPath`, (2) selecting that div, and (3) appending a text node containing the path with `textContent`. This preserves the visible behavior (still displays the requested path to the user) but removes the XSS risk because the untrusted string is never interpreted as HTML.

No new imports or external libraries are needed; we can rely on native DOM APIs (`querySelector`, `textContent`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
